### PR TITLE
Initialize frontend and backend for Gan Tzedaka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.env
+frontend/node_modules
+backend/node_modules
+npm-debug.log*
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# gantzdaka
+# Gan Tzedaka
+
+Gan Tzedaka is a full-stack web application. This repository contains the initial project setup with a React + TailwindCSS frontend and a Node.js + Express backend connected to MongoDB.
+
+## Project Structure
+
+- `frontend/` - React application configured with Vite and TailwindCSS.
+- `backend/` - Express server with MongoDB connection via Mongoose.
+
+Each project includes an `.env.example` file. Copy it to `.env` and adjust values as needed.
+
+## Scripts
+
+Run tests (placeholder):
+
+```bash
+npm test --prefix frontend
+npm test --prefix backend
+```
+

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+PORT=5000
+MONGO_URI=mongodb://localhost:27017/gan_tzedaka

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gan-tzedaka-backend",
+  "version": "1.0.0",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "echo 'No tests yet'"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "mongoose": "^7.3.2"
+  }
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,0 +1,27 @@
+require('dotenv').config();
+const express = require('express');
+const mongoose = require('mongoose');
+const cors = require('cors');
+
+const app = express();
+const port = process.env.PORT || 5000;
+const mongoUri = process.env.MONGO_URI || 'mongodb://localhost:27017/gan_tzedaka';
+
+app.use(cors());
+app.use(express.json());
+
+mongoose
+  .connect(mongoUri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  })
+  .then(() => console.log('Connected to MongoDB'))
+  .catch((err) => console.error('MongoDB connection error:', err));
+
+app.get('/', (req, res) => {
+  res.json({ message: 'Gan Tzedaka API' });
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gan Tzedaka</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "gan-tzedaka-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo 'No tests yet'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.23",
+    "tailwindcss": "^3.3.3",
+    "vite": "^4.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,9 @@
+function App() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Gan Tzedaka</h1>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold React + TailwindCSS frontend using Vite with basic App component and Tailwind config
- add Express backend with MongoDB connection and example environment variables
- document project structure and ignore environment files

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6894f95e7ed88323b6686c232d3ac275