### PR TITLE
Implement JWT-based authentication with role-specific access

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "mongoose": "^7.3.2"
+    "mongoose": "^7.3.2",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.0"
   }
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -10,6 +10,13 @@ const mongoUri = process.env.MONGO_URI || 'mongodb://localhost:27017/gan_tzedaka
 app.use(cors());
 app.use(express.json());
 
+// Routes
+const authRoutes = require('./routes/auth');
+const protectedRoutes = require('./routes/protected');
+
+app.use('/auth', authRoutes);
+app.use('/protected', protectedRoutes);
+
 mongoose
   .connect(mongoUri, {
     useNewUrlParser: true,

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,27 @@
+const jwt = require('jsonwebtoken');
+
+const authenticate = (req, res, next) => {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) {
+    return res.status(401).json({ message: 'No token provided' });
+  }
+
+  try {
+    const secret = process.env.JWT_SECRET || 'secret';
+    const decoded = jwt.verify(token, secret);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    res.status(401).json({ message: 'Invalid token' });
+  }
+};
+
+const authorize = (role) => (req, res, next) => {
+  if (req.user.role !== role) {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+  next();
+};
+
+module.exports = { authenticate, authorize };

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const UserSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  role: {
+    type: String,
+    enum: ['gan', 'charity', 'donor', 'admin'],
+    required: true,
+  },
+});
+
+module.exports = mongoose.model('User', UserSchema);

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+const router = express.Router();
+
+// Registration only for gan role
+router.post('/register', async (req, res) => {
+  const { name, email, password, role } = req.body;
+  if (role !== 'gan') {
+    return res.status(400).json({ message: 'Only gan registration is allowed' });
+  }
+  try {
+    const existing = await User.findOne({ email });
+    if (existing) {
+      return res.status(400).json({ message: 'User already exists' });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const user = new User({ name, email, password: hashed, role });
+    await user.save();
+    res.status(201).json({ message: 'Gan registered successfully' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// Login for all roles
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  try {
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(400).json({ message: 'Invalid credentials' });
+    }
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      return res.status(400).json({ message: 'Invalid credentials' });
+    }
+    const secret = process.env.JWT_SECRET || 'secret';
+    const token = jwt.sign(
+      { id: user._id, role: user.role },
+      secret,
+      { expiresIn: '1h' }
+    );
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/protected.js
+++ b/backend/src/routes/protected.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const { authenticate, authorize } = require('../middleware/auth');
+
+const router = express.Router();
+
+router.get('/gan', authenticate, authorize('gan'), (req, res) => {
+  res.json({ message: 'Gan protected route' });
+});
+
+router.get('/charity', authenticate, authorize('charity'), (req, res) => {
+  res.json({ message: 'Charity protected route' });
+});
+
+router.get('/donor', authenticate, authorize('donor'), (req, res) => {
+  res.json({ message: 'Donor protected route' });
+});
+
+router.get('/admin', authenticate, authorize('admin'), (req, res) => {
+  res.json({ message: 'Admin protected route' });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add bcryptjs and jsonwebtoken dependencies
- create User model with roles for gan, charity, donor, and admin
- implement registration for gan and login for all roles
- add JWT auth middleware and protected routes per role

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894fe7670808323b957b4a0e928b85c