### PR TITLE
Add public pages and basic form handling

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -13,9 +13,11 @@ app.use(express.json());
 // Routes
 const authRoutes = require('./routes/auth');
 const protectedRoutes = require('./routes/protected');
+const publicRoutes = require('./routes/public');
 
 app.use('/auth', authRoutes);
 app.use('/protected', protectedRoutes);
+app.use('/', publicRoutes);
 
 mongoose
   .connect(mongoUri, {

--- a/backend/src/models/Contact.js
+++ b/backend/src/models/Contact.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const ContactSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  email: { type: String, required: true },
+  message: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('Contact', ContactSchema);

--- a/backend/src/models/Registration.js
+++ b/backend/src/models/Registration.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const RegistrationSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  city: { type: String, required: true },
+  teacherName: { type: String, required: true },
+  phone: { type: String, required: true },
+  preferredCharities: [{ type: String }],
+  createdAt: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('Registration', RegistrationSchema);

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const Contact = require('../models/Contact');
+const Registration = require('../models/Registration');
+
+const router = express.Router();
+
+router.post('/contact', async (req, res) => {
+  try {
+    const { name, email, message } = req.body;
+    const contact = new Contact({ name, email, message });
+    await contact.save();
+    res.status(201).json({ message: 'Message received' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.post('/register', async (req, res) => {
+  try {
+    const { name, city, teacherName, phone, preferredCharities } = req.body;
+    const registration = new Registration({ name, city, teacherName, phone, preferredCharities });
+    await registration.save();
+    res.status(201).json({ message: 'Registration submitted' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,39 @@
-function App() {
+import Home from './pages/Home';
+import About from './pages/About';
+import Contact from './pages/Contact';
+import Register from './pages/Register';
+import Login from './pages/Login';
+
+export default function App() {
+  const path = window.location.pathname;
+  let Page;
+  switch (path) {
+    case '/about':
+      Page = About;
+      break;
+    case '/contact':
+      Page = Contact;
+      break;
+    case '/register':
+      Page = Register;
+      break;
+    case '/login':
+      Page = Login;
+      break;
+    default:
+      Page = Home;
+  }
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold">Gan Tzedaka</h1>
+    <div>
+      <nav className="p-4 bg-gray-100 flex space-x-4">
+        <a href="/">Home</a>
+        <a href="/about">About</a>
+        <a href="/contact">Contact</a>
+        <a href="/register">Register</a>
+        <a href="/login">Login</a>
+      </nav>
+      <Page />
     </div>
   );
 }
-
-export default App;

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -1,0 +1,12 @@
+export default function About() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-3xl font-bold">About Gan Tzedaka</h1>
+      <p>
+        Gan Tzedaka fosters generosity by guiding young children to engage with
+        meaningful charitable giving. Our values center on kindness, community,
+        and impactful learning experiences.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/Contact.jsx
+++ b/frontend/src/pages/Contact.jsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+
+export default function Contact() {
+  const [form, setForm] = useState({ name: '', email: '', message: '' });
+  const [status, setStatus] = useState('');
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus('');
+    try {
+      const res = await fetch('http://localhost:5000/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (res.ok) {
+        setStatus('Message sent');
+        setForm({ name: '', email: '', message: '' });
+      } else {
+        setStatus('Error sending message');
+      }
+    } catch (err) {
+      setStatus('Error sending message');
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <input
+          className="border p-2 w-full"
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+          placeholder="Name"
+        />
+        <input
+          className="border p-2 w-full"
+          name="email"
+          value={form.email}
+          onChange={handleChange}
+          placeholder="Email"
+        />
+        <textarea
+          className="border p-2 w-full"
+          name="message"
+          value={form.message}
+          onChange={handleChange}
+          placeholder="Message"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+          Send
+        </button>
+      </form>
+      {status && <p className="mt-4">{status}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,19 @@
+export default function Home() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-3xl font-bold">Gan Tzedaka</h1>
+      <section>
+        <h2 className="text-xl font-semibold">Vision</h2>
+        <p>Connecting young children with the joy of giving.</p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold">Process</h2>
+        <p>Classes learn about charities and choose where to donate.</p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold">Impact</h2>
+        <p>Empowering communities through early philanthropy.</p>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+
+export default function Login() {
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [status, setStatus] = useState('');
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus('');
+    try {
+      const res = await fetch('http://localhost:5000/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (res.ok) {
+        setStatus('Logged in');
+        setForm({ email: '', password: '' });
+      } else {
+        setStatus('Invalid credentials');
+      }
+    } catch (err) {
+      setStatus('Error logging in');
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-3xl font-bold mb-4">Login</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <input
+          className="border p-2 w-full"
+          name="email"
+          value={form.email}
+          onChange={handleChange}
+          placeholder="Email"
+        />
+        <input
+          className="border p-2 w-full"
+          type="password"
+          name="password"
+          value={form.password}
+          onChange={handleChange}
+          placeholder="Password"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+          Login
+        </button>
+      </form>
+      {status && <p className="mt-4">{status}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+
+const cities = ['Jerusalem', 'Tel Aviv', 'Haifa'];
+const charities = ['Charity A', 'Charity B', 'Charity C'];
+
+export default function Register() {
+  const [form, setForm] = useState({
+    name: '',
+    city: '',
+    teacherName: '',
+    phone: '',
+    preferredCharities: [],
+  });
+  const [status, setStatus] = useState('');
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleCharityChange = (e) => {
+    const value = e.target.value;
+    setForm((prev) => {
+      const selected = prev.preferredCharities.includes(value)
+        ? prev.preferredCharities.filter((c) => c !== value)
+        : [...prev.preferredCharities, value];
+      return { ...prev, preferredCharities: selected };
+    });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus('');
+    try {
+      const res = await fetch('http://localhost:5000/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (res.ok) {
+        setStatus('Registration submitted');
+        setForm({ name: '', city: '', teacherName: '', phone: '', preferredCharities: [] });
+      } else {
+        setStatus('Error submitting');
+      }
+    } catch (err) {
+      setStatus('Error submitting');
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-3xl font-bold mb-4">Gan Registration</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <input
+          className="border p-2 w-full"
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+          placeholder="Gan Name"
+        />
+        <select
+          className="border p-2 w-full"
+          name="city"
+          value={form.city}
+          onChange={handleChange}
+        >
+          <option value="">Select City</option>
+          {cities.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <input
+          className="border p-2 w-full"
+          name="teacherName"
+          value={form.teacherName}
+          onChange={handleChange}
+          placeholder="Teacher Name"
+        />
+        <input
+          className="border p-2 w-full"
+          name="phone"
+          value={form.phone}
+          onChange={handleChange}
+          placeholder="Phone"
+        />
+        <div>
+          <p className="font-semibold">Preferred Charities</p>
+          {charities.map((ch) => (
+            <label key={ch} className="block">
+              <input
+                type="checkbox"
+                value={ch}
+                checked={form.preferredCharities.includes(ch)}
+                onChange={handleCharityChange}
+                className="mr-2"
+              />
+              {ch}
+            </label>
+          ))}
+        </div>
+        <button type="submit" className="bg-green-500 text-white px-4 py-2">
+          Register
+        </button>
+      </form>
+      {status && <p className="mt-4">{status}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add Express models and routes to accept contact messages and gan registration forms
- Implement Home, About, Contact, Register and Login pages with simple navigation
- Store contact and registration data via new API endpoints

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6895016865b48323bcf6ee4a7b7e957b